### PR TITLE
Fix issues with Proxy and handle name of extracted folder differently

### DIFF
--- a/tasks/adopt-openjdk-installer/adopt-openjdk-api.ts
+++ b/tasks/adopt-openjdk-installer/adopt-openjdk-api.ts
@@ -2,10 +2,12 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as stream from 'stream';
 import { promisify } from 'util';
-import Got from 'got';
+import * as rm from 'typed-rest-client/RestClient'
+import * as ifm from 'typed-rest-client/Interfaces';
 import * as _ from 'lodash';
 import * as taskLib from 'azure-pipelines-task-lib/task';
 import * as toolLib from 'azure-pipelines-tool-lib/tool';
+import * as querystring from 'querystring';
 
 type AdoptOpenJDKApiBinaryEntry = {
     architecture: ArchitectureType,
@@ -34,20 +36,43 @@ type AdoptOpenJDKApiResultEntry = {
 };
 type AdoptOpenJDKApiResult = AdoptOpenJDKApiResultEntry[];
 
+let userAgent = 'adopt-openjdk-installer-devops/1.0';
+
+let requestOptions = {
+    // ignoreSslError: true,
+    proxy: taskLib.getHttpProxyConfiguration(),
+    cert: taskLib.getHttpCertConfiguration(),
+    allowRedirects: true,
+    allowRetries: true,
+    maxRetries: 2
+} as ifm.IRequestOptions;
+
 const pipeline = promisify(stream.pipeline);
+
+function getChildDirectories(root: string): string[] {
+    return fs.readdirSync(root, { withFileTypes: true })
+        .filter(dirent => dirent.isDirectory())
+        .map(dirent => dirent.name);
+}
 
 export async function fetch(os: OsType, jvm: JvmType, majorVersion: number, arch: ArchitectureType): Promise<AdoptOpenJDKApiBinaryEntry[]> {
     // const url = `https://api.adoptopenjdk.net/v3/assets/latest/${majorVersion}/${jvm}?release=latest`;
-    const url = `https://api.adoptopenjdk.net/v3/assets/feature_releases/${majorVersion}/ga?jvm_impl=${jvm}&os=${os}&vendor=adoptopenjdk&`;
-    const response = await Got.get<AdoptOpenJDKApiResult>(url, { responseType: 'json' });
 
-    response.body.forEach(release => {
-        release.binaries.forEach(b => {
-            b.release_name = release.release_name;
+    const url = `https://api.adoptopenjdk.net/v3/assets/feature_releases/${majorVersion}/ga?jvm_impl=${jvm}&os=${os}&vendor=adoptopenjdk&`;
+
+    const client = new rm.RestClient(userAgent, undefined, undefined, requestOptions);
+
+    const response = await client.get<AdoptOpenJDKApiResult>(url);
+
+    response.result.forEach(release => {
+        
+        release.binaries.forEach(b => {            
+            b.release_name = release.release_name
+            b.package.link = querystring.unescape(b.package.link);
         })
     });
 
-    return _.chain(response.body).map(e => e.binaries).flatten().filter(
+    return _.chain(response.result).map(e => e.binaries).flatten().filter(
         entry => entry?.os === os
             && entry?.architecture === arch
             && entry.image_type === 'jdk'
@@ -99,23 +124,48 @@ export async function downloadAndChecksum(entry: AdoptOpenJDKApiBinaryEntry, jdk
         console.log(`Using jdk root ${jdkRoot}`);
     }
 
+    console.log(`Downloading: ${link}`);
+
     const downloaded = await toolLib.downloadTool(link);
     console.log(`Downloaded file: ${downloaded}`);
 
     // TODO: Validate checksum
 
+    const extractedFolder = downloaded + '-extracted';
+
+    if (!taskLib.exist(extractedFolder)) {
+        console.log(`Creating temporary extract folder ${extractedFolder}`);
+        taskLib.mkdirP(extractedFolder);
+    }
+    else {
+        console.log(`Using temporary extract folder ${extractedFolder}`);
+    }
+
     // const cached = await toolLib.cacheFile(downloaded, name, 'openjdk-archive', entry.release_name, entry.binary.architecture);
     if (name.endsWith('.zip')) {
         try {
-            await toolLib.extractZip(downloaded, jdkRoot);
+            await toolLib.extractZip(downloaded, extractedFolder);
         } catch (error) {
-            await toolLib.extract7z(downloaded, jdkRoot);
+            await toolLib.extract7z(downloaded, extractedFolder);
         }
     }
     else if (name.endsWith('.tar') || name.endsWith('.tar.gz')) {
-        await toolLib.extractTar(downloaded, jdkRoot);
+        await toolLib.extractTar(downloaded, extractedFolder);
     } else {
-        await toolLib.extract7z(downloaded, jdkRoot);
+        await toolLib.extract7z(downloaded, extractedFolder);
+    }    
+
+    let childFolders: string[] = getChildDirectories(extractedFolder);
+
+    if (childFolders) {
+        if (childFolders.length == 1) {
+            console.log(`Moving ${childFolders[0]} to ${jdkDir}`);
+            taskLib.mv(path.join(extractedFolder, childFolders[0]), jdkDir, '-f');
+        } else {
+            throw `Found wrong number of child folders in ${extractedFolder} : ${childFolders.length}`
+        }
+    } else {
+        throw `Unable to locate child folders in ${extractedFolder}`
     }
 
     // console.log(`Caching jdk directory ${jdkDir}`);

--- a/tasks/adopt-openjdk-installer/package.json
+++ b/tasks/adopt-openjdk-installer/package.json
@@ -19,8 +19,8 @@
     "@types/q": "^1.5.2",
     "azure-pipelines-task-lib": "^2.9.3",
     "azure-pipelines-tool-lib": "^0.12.0",
-    "got": "^10.7.0",
-    "lodash": "^4.17.15"
+    "lodash": "^4.17.15",
+    "typed-rest-client": "^1.7.3"
   },
   "devDependencies": {
     "@types/chai": "^4.2.11",


### PR DESCRIPTION
Hello,

Great extension but I hit a few issues, two of them due to our setup of the build agent behind a proxy. The other one seems to be due to how the latest jdk 11 release has been packaged.

I've created a proposed fix. Could you have a look and see if it's possible to apply this?

**1) Proxy**
We run our build agents behind a proxy and both the download of the release manifest from AdoptOpenJDK and the JDK itself failed for different reasons.

1a) Manifest
The manifest because got did not get set up with proxy. I switched to typed-rest-client as I found an easy sample on how to set this up without too much fuss. This is the client used by Azure DevOps libraries anyways.

1b) downloadTool command
For the downloadTool command I've filed an issue with Microsoft here. The azure-pipelines-tool-lib package contains it's own copy of tunnel which does not work well with AWS where GitHub hosts their filed. It adds :443 to the request which causes the request signature validation by AWS to fail.
https://github.com/microsoft/azure-pipelines-tool-lib/issues/71

**2) JDK 11.0.7**
The current mainifest contains the latest version as "jdk-11.0.7+10.2" however when downloaded and extracted it's placed in a folder called "jdk-11.0.7+10"

I worked around that by downloading to a temporary folder and then moving the first folder it can find inside to the correct tool folder.
